### PR TITLE
use `ots-skip-outline-level' in `ots-slide-content'

### DIFF
--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -268,7 +268,8 @@ Profiles:
     (ots-hide-slide-header)
     (ots-move-to-the-first-heading)
     (org-overview)
-    (org-content)
+    (org-content (if (> org-tree-slide-skip-outline-level 0)
+                     (1- org-tree-slide-skip-outline-level)))
     (message "<<  CONTENT  >>")))
 
 ;;;###autoload


### PR DESCRIPTION
Hello,
what do you think about this?

I found that those headlines skipped by `ots-skip-outline-level` don't need to show up when displaying the toc.