### PR TITLE
Added org-tree-slide--show-subtree

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-12  Stefano BENNATI  <st.bennati@gmail.com>
+
+	* org-tree-slide.el: Subtrees that start with 'COMMENT' will be hidden during presentation
+	- org-tree-slide--show-subtree is added
+
 2015-08-09  Takaaki ISHIKAWA  <takaxp@ieee.org>
 
 	* org-tree-slide.el: Added a flag to reveal subtrees to be skipped
@@ -198,4 +203,3 @@
 2011-09-28  Takaaki ISHIKAWA  <takaxp@ieee.org>
 
 	* org-tree-slide.el: Initial release
-

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
 	* org-tree-slide.el: Subtrees that start with 'COMMENT' will be hidden during presentation
 	- org-tree-slide--show-subtree is added
+	- org-tree-slide--hide-subtree is added
+	- org-tree-slide-hide-subtrees-commented is added, it controls wether the heading of a commented subtree should be hidden
 
 2015-08-09  Takaaki ISHIKAWA  <takaxp@ieee.org>
 

--- a/README.org
+++ b/README.org
@@ -1,13 +1,13 @@
 #+TITLE:	README for Org Tree Slide
 #+AUTHOR:	Takaaki Ishikawa
 #+EMAIL:	takaxp@ieee.org
-#+DATE:		2015-08-09
+#+DATE:		2015-08-13
 #+UPDATE:	01:19:10
 #+STARTUP:	content
 
 * 1. What's this?
 
-The main purpose of this elisp is to handle each tree in an org buffer as a slide by simple narrowing. This emacs lisp is a minor mode for Emacs Org-mode. 
+The main purpose of this elisp is to handle each tree in an org buffer as a slide by simple narrowing. This emacs lisp is a minor mode for Emacs Org-mode.
 
 Main features:
 
@@ -137,23 +137,24 @@ If you feel the cursor moving is very slow, please change a value of =org-tree-s
 
 * 5. User variables
 
-|----+--------------------------------------+---------------+---------|
-|    | Variable                             | Default value | Select  |
-|----+--------------------------------------+---------------+---------|
-|  1 | org-tree-slide-skip-outline-level    | 0             | Numeric |
-|  2 | org-tree-slide-header                | t             | Boolean |
-|  3 | org-tree-slide-slide-in-effect       | t             | Boolean |
-|  4 | org-tree-slide-cursor-init           | t             | Boolean |
-|  5 | org-tree-slide-slide-in-brank-lines  | 10            | Numeric |
-|  6 | org-tree-slide-slide-in-waiting      | 0.02          | Float   |
-|  7 | org-tree-slide-heading-emphasis      | nil           | Boolean |
-|  8 | org-tree-slide-never-touch-face      | nil           | Boolean |
-|  9 | org-tree-slide-skip-done             | nil           | Boolean |
-| 10 | org-tree-slide-skip-comments         | t             | Boolean |
-| 11 | org-tree-slide-activate-message      | Hello...      | String  |
-| 12 | org-tree-slide-deactivate-message    | Quit, Bye!    | String  |
-| 13 | org-tree-slide-modeline-display      | 'outside      | [*1]    |
-| 14 | org-tree-slide-fold-subtrees-skipped | t             | Boolean |
+|----+----------------------------------------+---------------+---------|
+|    | Variable                               | Default value | Select  |
+|----+----------------------------------------+---------------+---------|
+|  1 | org-tree-slide-skip-outline-level      | 0             | Numeric |
+|  2 | org-tree-slide-header                  | t             | Boolean |
+|  3 | org-tree-slide-slide-in-effect         | t             | Boolean |
+|  4 | org-tree-slide-cursor-init             | t             | Boolean |
+|  5 | org-tree-slide-slide-in-brank-lines    | 10            | Numeric |
+|  6 | org-tree-slide-slide-in-waiting        | 0.02          | Float   |
+|  7 | org-tree-slide-heading-emphasis        | nil           | Boolean |
+|  8 | org-tree-slide-never-touch-face        | nil           | Boolean |
+|  9 | org-tree-slide-skip-done               | nil           | Boolean |
+| 10 | org-tree-slide-skip-comments           | t             | Boolean |
+| 11 | org-tree-slide-activate-message        | Hello...      | String  |
+| 12 | org-tree-slide-deactivate-message      | Quit, Bye!    | String  |
+| 13 | org-tree-slide-modeline-display        | 'outside      | [*1]    |
+| 14 | org-tree-slide-fold-subtrees-skipped   | t             | Boolean |
+| 15 | org-tree-slide-hide-subtrees-commented | t             | Boolean |
 
 #+BEGIN_QUOTE
 [*1] { nil| 'lighter | 'outside }

--- a/README.org
+++ b/README.org
@@ -226,44 +226,45 @@ NOTE: For senior user, some hook were renamed, please update your configurations
 
 see also ChangeLog
 
-|---------+------------------+-------------------------------------------------|
-| Version | Date             | Description                                     |
-|---------+------------------+-------------------------------------------------|
-| v2.8.3  | 2015-08-09@01:04 | Added a flag to reveal subtrees to be skipped   |
-| v2.8.1  | 2015-02-27@10:42 | Hide org-clock related code                     |
-| v2.8.0  | 2015-02-20@21:27 | Changed Keymap, and renamed/added hooks         |
-| v2.7.5  | 2015-02-15@16:29 | Replace ots- with org-tree-slide--              |
-| v2.7.4  | 2015-02-14@23:30 | Refine displaying slide number in modeline      |
-| v2.7.2  | 2015-01-12@19:56 | Suppress an error message from org-timer        |
-| v2.7.1  | 2015-01-12@18:28 | Hide skipped slides when CONTENT mode           |
-| v2.7.0  | 2013-07-21@05:21 | Support buffers without headings                |
-| v2.6.8  | 2013-02-19@12:49 | Added a flag to control face setting            |
-| v2.6.6  | 2013-02-19@11:22 | Added a new toggle to skip commented trees      |
-| v2.6.4  | 2013-02-12@01:43 | Added some features (issue #2, #5, and #7)      |
-| v2.6.2  | 2013-01-27@21:21 | Added hooks for start and stop the presentation |
-| v2.6.0  | 2012-11-21@02:14 | Support dark color theme (by @uk-ar)            |
-| v2.5.4  | 2012-01-11@23:02 | Add autoload magic comments                     |
-| v2.5.3  | 2011-12-18@00:50 | Fix a bug for an org buffer without header      |
-| v2.5.2  | 2011-12-17@17:52 | Set presentation profile as the default         |
-| v2.5.1  | 2011-12-17@13:34 | org-tree-slide-skip-done set nil as default     |
-| v2.5.0  | 2011-12-12@18:16 | Remove auto-play function (TBD)                 |
-| v2.4.1  | 2011-12-09@11:46 | Add an option to control mode line display      |
-| v2.4.0  | 2011-12-08@10:51 | Support TODO pursuit in a slideshow             |
-| v2.3.2  | 2011-12-08@09:22 | Reduce redundant processing                     |
-| v2.3.1  | 2011-12-07@20:30 | Add a new profile to control narrowing status   |
-| v2.3.0  | 2011-12-07@16:17 | Support displaying a slide number               |
-| v2.2.0  | 2011-12-07@02:15 | Support minor mode                              |
-| v2.1.7  | 2011-12-06@00:26 | Support TITLE/AUTHOR/EMAIL in a header          |
-| v2.1.5  | 2011-12-05@17:08 | Fix an issue of title display                   |
-| v2.1.3  | 2011-12-05@15:08 | Fix the end of slide for skip control           |
-| v2.1.1  | 2011-12-05@11:08 | Add skip control by heading level               |
-| v2.0.1  | 2011-12-02@18:29 | Change function names, ots- is introduced.      |
-| v2.0.0  | 2011-12-01@17:41 | Add profiles and support org 6.33x              |
-| v1.2.5  | 2011-10-31@18:34 | Add CONTENT view to see all the subtrees.       |
-| v1.2.3  | 2011-10-30@20:42 | Add a variable to control slide-in duration     |
-| v1.2.1  | 2011-10-30@16:10 | Add slide-in visual effect                      |
-| v1.1.1  | 2011-10-28@16:16 | Add functions to start and stop slide view      |
-| v1.0.0  | 2011-09-28@20:59 | Release the initial version                     |
+|---------+------------------+---------------------------------------------------|
+| Version | Date             | Description                                       |
+|---------+------------------+---------------------------------------------------|
+| v2.8.4  | 2015-08-12@21:35 | Subtrees that start with 'COMMENT' will be hidden |
+| v2.8.3  | 2015-08-09@01:04 | Added a flag to reveal subtrees to be skipped     |
+| v2.8.1  | 2015-02-27@10:42 | Hide org-clock related code                       |
+| v2.8.0  | 2015-02-20@21:27 | Changed Keymap, and renamed/added hooks           |
+| v2.7.5  | 2015-02-15@16:29 | Replace ots- with org-tree-slide--                |
+| v2.7.4  | 2015-02-14@23:30 | Refine displaying slide number in modeline        |
+| v2.7.2  | 2015-01-12@19:56 | Suppress an error message from org-timer          |
+| v2.7.1  | 2015-01-12@18:28 | Hide skipped slides when CONTENT mode             |
+| v2.7.0  | 2013-07-21@05:21 | Support buffers without headings                  |
+| v2.6.8  | 2013-02-19@12:49 | Added a flag to control face setting              |
+| v2.6.6  | 2013-02-19@11:22 | Added a new toggle to skip commented trees        |
+| v2.6.4  | 2013-02-12@01:43 | Added some features (issue #2, #5, and #7)        |
+| v2.6.2  | 2013-01-27@21:21 | Added hooks for start and stop the presentation   |
+| v2.6.0  | 2012-11-21@02:14 | Support dark color theme (by @uk-ar)              |
+| v2.5.4  | 2012-01-11@23:02 | Add autoload magic comments                       |
+| v2.5.3  | 2011-12-18@00:50 | Fix a bug for an org buffer without header        |
+| v2.5.2  | 2011-12-17@17:52 | Set presentation profile as the default           |
+| v2.5.1  | 2011-12-17@13:34 | org-tree-slide-skip-done set nil as default       |
+| v2.5.0  | 2011-12-12@18:16 | Remove auto-play function (TBD)                   |
+| v2.4.1  | 2011-12-09@11:46 | Add an option to control mode line display        |
+| v2.4.0  | 2011-12-08@10:51 | Support TODO pursuit in a slideshow               |
+| v2.3.2  | 2011-12-08@09:22 | Reduce redundant processing                       |
+| v2.3.1  | 2011-12-07@20:30 | Add a new profile to control narrowing status     |
+| v2.3.0  | 2011-12-07@16:17 | Support displaying a slide number                 |
+| v2.2.0  | 2011-12-07@02:15 | Support minor mode                                |
+| v2.1.7  | 2011-12-06@00:26 | Support TITLE/AUTHOR/EMAIL in a header            |
+| v2.1.5  | 2011-12-05@17:08 | Fix an issue of title display                     |
+| v2.1.3  | 2011-12-05@15:08 | Fix the end of slide for skip control             |
+| v2.1.1  | 2011-12-05@11:08 | Add skip control by heading level                 |
+| v2.0.1  | 2011-12-02@18:29 | Change function names, ots- is introduced.        |
+| v2.0.0  | 2011-12-01@17:41 | Add profiles and support org 6.33x                |
+| v1.2.5  | 2011-10-31@18:34 | Add CONTENT view to see all the subtrees.         |
+| v1.2.3  | 2011-10-30@20:42 | Add a variable to control slide-in duration       |
+| v1.2.1  | 2011-10-30@16:10 | Add slide-in visual effect                        |
+| v1.1.1  | 2011-10-28@16:16 | Add functions to start and stop slide view        |
+| v1.0.0  | 2011-09-28@20:59 | Release the initial version                       |
 
 * 8. Contact
 

--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -95,6 +95,13 @@
   :type 'boolean
   :group 'org-tree-slide)
 
+(defcustom org-tree-slide-hide-subtrees-commented t
+  "If this flag is true, the commented subtrees in a slide will be hidden
+   When nil, the heading of the subtrees will be revealed.
+"
+  :type 'boolean
+  :group 'org-tree-slide)
+
 (defcustom org-tree-slide-header t
   "The status of displaying the slide header"
   :type 'boolean
@@ -558,11 +565,29 @@ Profiles:
     (outline-map-region
      (lambda ()
        (if (org-tree-slide--heading-skip-comment-p)
-           (hide-subtree)
+           (org-tree-slide--hide-subtree)
          (show-subtree)))
      (point)
      (progn (outline-end-of-subtree)
             (if (eobp) (point-max) (1+ (point)))))))
+
+
+
+(defun org-tree-slide--hide-subtree ()
+  "Hides subtree. The headline is revealed if org-tree-slide-hide-subtrees-commented is nil, else the headline is hidden"
+  (if org-tree-slide-hide-subtrees-commented
+      (let* ((from (progn (outline-back-to-heading) (point)))
+             (to (progn (outline-end-of-subtree) (point)))
+             (temp (remove-overlays from to 'invisible 'outline))
+             (o (make-overlay from to nil)))
+        ;;(overlay-put o 'evaporate t)
+        (overlay-put o 'invisible 'outline)
+        (overlay-put o 'isearch-open-invisible
+                     (or outline-isearch-open-invisible-function
+                         'outline-isearch-open-invisible))
+        )
+    (hide-subtree)
+    ))
 
 
 (defun org-tree-slide--outline-next-heading ()

--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -68,7 +68,7 @@
 (require 'org-timer)
 ;;(require 'org-clock)			; org-clock-in, -out, -clocking-p
 
-(defconst org-tree-slide "2.8.3"
+(defconst org-tree-slide "2.8.4"
   "The version number of the org-tree-slide.el")
 
 (defgroup org-tree-slide nil
@@ -539,7 +539,7 @@ Profiles:
     ;; If this is the last level to be displayed, show the full content
     (if (and (not org-tree-slide-fold-subtrees-skipped)
              (org-tree-slide--heading-level-skip-p (1+ (org-outline-level))))
-        (org-show-subtree)
+        (org-tree-slide--show-subtree)
       (show-children))
     ;;    (org-cycle-hide-drawers 'all) ; disabled due to performance reduction
     (org-narrow-to-subtree))
@@ -549,6 +549,21 @@ Profiles:
     (org-tree-slide--show-slide-header))
   (run-hooks 'org-tree-slide-after-narrow-hook)
   (run-hooks 'org-tree-slide-mode-after-narrow-hook))
+
+(defun org-tree-slide--show-subtree ()
+  "Hide all subtrees that "
+  (interactive "P")
+  (save-excursion
+    (outline-back-to-heading)
+    (outline-map-region
+     (lambda ()
+       (if (org-tree-slide--heading-skip-comment-p)
+           (hide-subtree)
+         (show-subtree)))
+     (point)
+     (progn (outline-end-of-subtree)
+            (if (eobp) (point-max) (1+ (point)))))))
+
 
 (defun org-tree-slide--outline-next-heading ()
   (org-tree-slide--outline-select-method


### PR DESCRIPTION
Subtrees that start with 'COMMENT' will be hidden during presentation.