### PR TITLE
org-tree-slide-content: Return to exact point in slide presentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-06-30  Boruch Baum  <boruch_baum@gmx.com>
+
+	* org-tree-slide.el (org-tree-slide-content): Toggle back to slide
+	presentation, to exact position where you left off.
+	(org-tree-slide-content-pos): New variable to support this feature.
+
 2018-11-26  Takaaki ISHIKAWA  <takaxp@ieee.org>
 
 	* org-tree-slide.el: Extract header colors from default face of frame
@@ -235,4 +241,3 @@
 2011-09-28  Takaaki ISHIKAWA  <takaxp@ieee.org>
 
 	* org-tree-slide.el: Initial release
-

--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -238,6 +238,8 @@ nil: keep the same position."
   "A hook run before moving to the previous slide.")
 (defvar org-tree-slide-before-content-view-hook nil
   "A hook run before showing the content.")
+(defvar org-tree-slide-content-pos nil
+  "Where to return when toggling function `org-tree-slide-content'.")
 
 ;;;###autoload
 (define-minor-mode org-tree-slide-mode
@@ -312,16 +314,29 @@ Profiles:
   "Change the display for viewing content of the org file during the slide view mode is active."
   (interactive)
   (when (org-tree-slide--active-p)
-    (run-hooks 'org-tree-slide-before-content-view-hook)
-    (widen)
-    (org-tree-slide--hide-slide-header)
-    (org-tree-slide--move-to-the-first-heading)
-    (org-overview)
-    (cond ((eq 0 org-tree-slide-skip-outline-level)
-           (org-content))
-          ((< 2 org-tree-slide-skip-outline-level)
-           (org-content (1- org-tree-slide-skip-outline-level))))
-    (message "<<  CONTENT  >>")))
+    (cond
+     (org-tree-slide-content-pos
+;     (widen)
+      (goto-char org-tree-slide-content-pos)
+      (org-tree-slide--display-tree-with-narrow)
+      (goto-char org-tree-slide-content-pos)
+      (setq org-tree-slide-content-pos nil))
+     (t
+      (setq org-tree-slide-content-pos
+        (max (1+ (point-min)) (point)))
+      (run-hooks 'org-tree-slide-before-content-view-hook)
+      (widen)
+      (org-tree-slide--hide-slide-header)
+      (org-tree-slide--move-to-the-first-heading)
+      (org-overview)
+      (cond ((eq 0 org-tree-slide-skip-outline-level)
+             (org-content))
+            ((< 2 org-tree-slide-skip-outline-level)
+             (org-content (1- org-tree-slide-skip-outline-level))))
+;     (goto-char (point-min))
+      (redisplay)
+      (goto-char org-tree-slide-content-pos)
+      (message "<<  CONTENT  >>")))))
 
 ;;;###autoload
 (defun org-tree-slide-move-next-tree ()


### PR DESCRIPTION
+ When entering content-view, this places the cursor at the point in
  the heading tree where the user was, instead of always at the top of
  the file.

+ With this feature, a user can enter content-view, and return to the
  exact position within the presentation in just one command, M-x
  org-tree-slide-content.

  + Works even after navigating within content-view.

  + Useful also when forgetting exactly where one had been before
    entering content-view.

+ The patch includes two commented lines that can be deleted. I kept
  them mainly as notes how the package was operating in other
  functions, just in case something went wrong.
