### PR TITLE
Add org-tree-slide-exit-at-next-last-slide and -before-hook

### DIFF
--- a/README.org
+++ b/README.org
@@ -175,6 +175,7 @@ If you feel the cursor moving is very slow, please change a value of =org-tree-s
 | 15 | org-tree-slide-breadcrumbs                 | " > "         | String  |
 | 16 | org-tree-slide-breadcrumbs-hide-todo-state | t             | Boolean |
 | 17 | org-tree-slide-indicator                   | plist         | [*2]    |
+| 18 | org-tree-slide-exit-at-next-last-slide     | nil           | Boolean |
 
 #+begin_quote
 [*1] { nil| 'lighter | 'outside }
@@ -244,6 +245,7 @@ These functions will toggle =org-tree-slide-mode= ON, automatically.
   - org-tree-slide-after-narrow-hook
   - org-tree-slide-before-move-next-hook
   - org-tree-slide-before-move-previous-hook
+  - org-tree-slide-before-exit-hook
 
 NOTE: For senior user, some hook were renamed, please update your configurations
 

--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -186,6 +186,12 @@ If you want to show anything, just specify nil."
   :type 'plist
   :group 'org-tree-slide)
 
+(defcustom org-tree-slide-exit-at-next-last-slide nil
+  "Exit at right next door to the last slide if this value is non-nil.
+Otherwise stay in content."
+  :type 'boolean
+  :group 'org-tree-slide)
+
 (defvar org-tree-slide-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-x s c") 'org-tree-slide-content)
@@ -250,6 +256,8 @@ If you want to show anything, just specify nil."
   "A hook run before moving to the previous slide.")
 (defvar org-tree-slide-before-content-view-hook nil
   "A hook run before showing the content.")
+(defvar org-tree-slide-before-exit-hook nil
+  "A hook run before exit from `org-tree-slide-mode'")
 
 ;;;###autoload
 (define-minor-mode org-tree-slide-mode
@@ -367,7 +375,12 @@ Profiles:
      ;; displaying a slide, not the contents
      ((and (buffer-narrowed-p)
            (org-tree-slide--last-tree-p (point)))
-      (org-tree-slide-content))
+      (if org-tree-slide-exit-at-next-last-slide
+          ;; exit at right next door to the last slide
+          (progn
+            (run-hooks 'org-tree-slide-before-exit-hook)
+            (org-tree-slide-mode 0))
+        (org-tree-slide-content)))
      ((or
        (or (and (org-tree-slide--before-first-heading-p)
                 (not (org-at-heading-p)))


### PR DESCRIPTION
Hi !

This package is marvelous!
However I'd like to exit the slideshow at arriving to last slide. Then my trivial ideal will be realized perfectly like below if org-tree-mode-exit-hook is added to this package.

https://vimeo.com/490095476

``` emacs-lisp
(defun enter-the-prezn ()
  (setq org-tree-slide-exit-at-next-last-slide t)
(add-hook 'org-tree-slide-play-hook #'enter-the-prezn)

(defun sayonara ()
  (lexical-let ((animate-n-steps 60)
                (vpos 10))
    (animate-string "Thank you for watching!" vpos))
  (sit-for 3))
(add-hook 'org-tree-slide-before-exit-hook #'sayonara)
```

すみません。英語しんどくなってきたので日本語使わせてください ^_^;

プレゼンが最後まで行ったらそのまま`C->`を押して抜けるようにしたかったのと、抜けるとき用のフックが欲しかったので足してみました。

変なところに足しててすみません。（`org-tree-slide-stop-hook`でやろうとしたのですが、「中断」的なとき用の感じがしたので新たに足してみました。）

設計思想と違う場合はお知らせください。