### PR TITLE
Create custom variable org-tree-slide-content-margin-top

### DIFF
--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -112,6 +112,11 @@ When nil, the body of the subtrees will be revealed."
   :type 'boolean
   :group 'org-tree-slide)
 
+(defcustom org-tree-slide-content-margin-top 2
+  "Specify the number of blank lines, the slide will move from this line."
+  :type 'integer
+  :group 'org-tree-slide)
+
 (defcustom org-tree-slide-slide-in-effect t
   "Using a visual effect of slide-in for displaying trees."
   :type 'boolean
@@ -711,7 +716,7 @@ If HEADING-LEVEL is non-nil, the provided outline level is checked."
   "Apply slide in.  The slide will be moved from BLANK-LINES below to top."
   (let ((min-line -1))
     (when org-tree-slide-header
-      (setq min-line 2))
+      (setq min-line org-tree-slide-content-margin-top))
     (while (< min-line blank-lines)
       (org-tree-slide--set-slide-header blank-lines)
       (sit-for org-tree-slide-slide-in-waiting)
@@ -830,7 +835,7 @@ Some number of BLANK-LINES will be shown below the header."
 
 (defun org-tree-slide--show-slide-header (&optional lines)
   "Show header.  When LINES is nil, the default value is 2."
-  (org-tree-slide--set-slide-header (or lines 2)))
+  (org-tree-slide--set-slide-header (or lines org-tree-slide-content-margin-top)))
 
 (defun org-tree-slide--hide-slide-header ()
   "Hide header."


### PR DESCRIPTION
Bigger margin may look better in presentations with less content. Here is a screenshot of the margin that this PR will add a custom variable to change its size.

![org-tree-slide-margin](https://user-images.githubusercontent.com/29731420/102034578-652e7480-3dcf-11eb-8208-af7550a4833d.png)
