### PR TITLE
Update the docstring of org-tree-slide-content-margin-top variable

### DIFF
--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -113,7 +113,7 @@ When nil, the body of the subtrees will be revealed."
   :group 'org-tree-slide)
 
 (defcustom org-tree-slide-content-margin-top 2
-  "Specify the number of blank lines, the slide will move from this line."
+  "Specify the margin between the slide header and its content."
   :type 'integer
   :group 'org-tree-slide)
 


### PR DESCRIPTION
I accidentally forgot to change the docstring of the new variable I created. I copied it from another variable but forgot to write new docstring then. You did not notice it either because of the similarities of variables I guess. Sorry for the mistake. Thanks for quick response btw.