### PR TITLE
Allow empty date and author to save on-screen space

### DIFF
--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -796,12 +796,16 @@ Some number of BLANK-LINES will be shown below the header."
       (overlay-put org-tree-slide--header-overlay 'display
                    (concat (if org-tree-slide-title org-tree-slide-title
                              (buffer-name))
-                           "\n"
-                           org-tree-slide-date "  "
-                           (when org-tree-slide-author
-                             (concat org-tree-slide-author "  "))
-                           (when org-tree-slide-email
-                             (concat "<" org-tree-slide-email ">"))
+
+                           ;; Use one line for date and author (but only if either of those is set)
+                           (when (or org-tree-slide-date org-tree-slide-author org-tree-slide-email)
+                             "\n"
+                             org-tree-slide-date "  "
+                             (when org-tree-slide-author
+                               (concat org-tree-slide-author "  "))
+                             (when org-tree-slide-email
+                               (concat "<" org-tree-slide-email ">")))
+
                            (when org-tree-slide-breadcrumbs
                              (concat "\n" (org-tree-slide--get-parents
                                            org-tree-slide-breadcrumbs)))


### PR DESCRIPTION
I tend to just put the author and date on the title page, preferring
them to be not displayed on each slide.

This commit will not use the line that's currently displaying date and
author, removing the empty "\n" if both author and date are set to empty
strings.