### PR TITLE
address warning messages given during native compilation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2023-02-23  Lukas Zumvorde  <lukaszumvorde@web.de>
+
+	* org-tree-slide.el: Prevent warning messages during native compilation
+	Add line breaks to docstrings to shorten them to <80 characters per line
+	Replace deprecated function calls with their new equivalents
+	- hide-subtree -> outline-hide-subtree
+	- show-children -> outline-show-children
+	- show-subtree -> outline-show-subtree
+	require face-remap file explicitly to ensure face-remap-remove-relative is loaded
+	Add missing type definition to defcustom of org-subtree-slide-heading-level-{1,2,3,4}
+
 2020-06-11  Takaaki ISHIKAWA  <takaxp@ieee.org>
 
 	* org-tree-slide.el: Depends on emacs 24.3

--- a/org-tree-slide.el
+++ b/org-tree-slide.el
@@ -77,6 +77,7 @@
 
 (require 'org)
 (require 'org-timer)
+(require 'face-remap)
 
 (defconst org-tree-slide "2.8.18"
   "The version number of the org-tree-slide.el.")
@@ -126,7 +127,8 @@ When nil, the body of the subtrees will be revealed."
   "Specify a cursor position at start and exit of the slideshow.
 
 Non-nil: the cursor will move automatically to the head of buffer.
-nil: keep the same position.  The slideshow will start from the heading that has the cursor."
+nil: keep the same position.  The slideshow will start from the heading
+     that has the cursor."
   :type 'boolean
   :group 'org-tree-slide)
 
@@ -203,21 +205,25 @@ If you want to show anything, just specify nil."
 (defcustom org-tree-slide-heading-level-1
   '(outline-1 :height 1.5 bold)
   "Level 1."
+  :type 'list
   :group 'org-tree-slide)
 
 (defcustom org-tree-slide-heading-level-2
   '(outline-2 :height 1.4 bold)
   "Level 2."
+  :type 'list
   :group 'org-tree-slide)
 
 (defcustom org-tree-slide-heading-level-3
   '(outline-3 :height 1.3 bold)
   "Level 3."
+  :type 'list
   :group 'org-tree-slide)
 
 (defcustom org-tree-slide-heading-level-4
   '(outline-4 :height 1.2 bold)
   "Level 4."
+  :type 'list
   :group 'org-tree-slide)
 
 (defvar-local org-tree-slide-heading-level-1-cookie nil)
@@ -313,7 +319,8 @@ Profiles:
 
 ;;;###autoload
 (defun org-tree-slide-content ()
-  "Change the display for viewing content of the org file during the slide view mode is active."
+  "Change the display for viewing content of the org file during the
+slide view mode is active."
   (interactive)
   (when (org-tree-slide--active-p)
     (cond
@@ -566,7 +573,9 @@ This is displayed by default if `org-tree-slide-modeline-display' is nil.")
       (message "%s" org-tree-slide-activate-message))))
 
 (defvar org-tree-slide-startup "overview"
-  "If you have \"#+startup:\" line in your org buffer, the org buffer will be shown with corresponding status (content, showall, overview:default).")
+  "If you have \"#+startup:\" line in your org buffer,
+the org buffer will be shown with corresponding status
+(content, showall, overview:default).")
 
 (defun org-tree-slide--stop ()
   "Stop the slide view, and redraw the orgmode buffer with #+STARTUP:."
@@ -600,13 +609,13 @@ This is displayed by default if `org-tree-slide-modeline-display' is nil.")
     (setq org-tree-slide--previous-line (org-tree-slide--line-number-at-pos)))
   (goto-char (point-at-bol))
   (unless (org-tree-slide--before-first-heading-p)
-    (hide-subtree)	; support CONTENT (subtrees are shown)
+    (outline-hide-subtree)	; support CONTENT (subtrees are shown)
     (org-show-entry)
     ;; If this is the last level to be displayed, show the full content
     (if (and (not org-tree-slide-fold-subtrees-skipped)
              (org-tree-slide--heading-level-skip-p (1+ (org-outline-level))))
         (org-tree-slide--show-subtree)
-      (show-children))
+      (outline-show-children))
     ;;    (org-cycle-hide-drawers 'all) ; disabled due to performance reduction
     (org-narrow-to-subtree))
   (when org-tree-slide-slide-in-effect
@@ -622,8 +631,8 @@ This is displayed by default if `org-tree-slide-modeline-display' is nil.")
     (outline-map-region
      (lambda ()
        (if (org-tree-slide--heading-skip-comment-p)
-           (hide-subtree)
-         (show-subtree)
+           (outline-hide-subtree)
+         (outline-show-subtree)
          (org-cycle-hide-drawers 'all)))
      (point)
      (progn (outline-end-of-subtree)
@@ -708,13 +717,17 @@ If HEADING-LEVEL is non-nil, the provided outline level is checked."
       (setq blank-lines (1- blank-lines)))))
 
 (defvar org-tree-slide-title nil
-  "If you have \"#+title:\" line in your org buffer, it wil be used as a title of the slide.  If the buffer has no \"#+title:\" line, the name of current buffer will be displayed.")
+  "If you have \"#+title:\" line in your org buffer, it wil be used as a title
+of the slide.  If the buffer has no \"#+title:\" line, the name of
+current buffer will be displayed.")
 
 (defvar org-tree-slide-email nil
-  "If you have \"#+email:\" line in your org buffer, it will be used as an address of the slide.")
+  "If you have \"#+email:\" line in your org buffer,
+it will be used as an address of the slide.")
 
 (defvar org-tree-slide-author nil
-  "If you have \"#+author:\" line in your org buffer, it will be used as a name of the slide author.")
+  "If you have \"#+author:\" line in your org buffer,
+it will be used as a name of the slide author.")
 
 (defvar org-tree-slide-date nil
   "If you have \"#+date:\" line in your org buffer, it will be used as the date.")


### PR DESCRIPTION
When compiling with emacs-lisp-native-compile-and-load several warning messages were given.
Those are addressed in this commit.

The warnings were
```
Compiling file <path-to-file>/org-tree-slide.el at Thu Feb 23 16:26:00 2023
org-tree-slide.el:125:1: Warning: custom-declare-variable
    `org-tree-slide-cursor-init' docstring wider than 80 characters
org-tree-slide.el:203:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-1’ fails to specify type
org-tree-slide.el:203:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-1’ fails to specify type
org-tree-slide.el:208:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-2’ fails to specify type
org-tree-slide.el:208:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-2’ fails to specify type
org-tree-slide.el:213:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-3’ fails to specify type
org-tree-slide.el:213:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-3’ fails to specify type
org-tree-slide.el:218:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-4’ fails to specify type
org-tree-slide.el:218:1: Warning: defcustom for
    ‘org-tree-slide-heading-level-4’ fails to specify type

In org-tree-slide-content:
org-tree-slide.el:315:8: Warning: docstring wider than 80 characters
org-tree-slide.el:568:1: Warning: defvar `org-tree-slide-startup' docstring
    wider than 80 characters

In org-tree-slide--display-tree-with-narrow:
org-tree-slide.el:603:6: Warning: ‘hide-subtree’ is an obsolete function (as
    of 25.1); use ‘outline-hide-subtree’ instead.
org-tree-slide.el:609:8: Warning: ‘show-children’ is an obsolete function (as
    of 25.1); use ‘outline-show-children’ instead.

In org-tree-slide--show-subtree:
org-tree-slide.el:625:13: Warning: ‘hide-subtree’ is an obsolete function (as
    of 25.1); use ‘outline-hide-subtree’ instead.
org-tree-slide.el:626:11: Warning: ‘show-subtree’ is an obsolete function (as
    of 25.1); use ‘outline-show-subtree’ instead.
org-tree-slide.el:710:1: Warning: defvar `org-tree-slide-title' docstring
    wider than 80 characters
org-tree-slide.el:713:1: Warning: defvar `org-tree-slide-email' docstring
    wider than 80 characters
org-tree-slide.el:716:1: Warning: defvar `org-tree-slide-author' docstring
    wider than 80 characters

In end of data:
org-tree-slide.el:855:8: Warning: the function ‘face-remap-remove-relative’ is
    not known to be defined.
```
To address them i added the following changes 

Add line breaks to docstrings to shorten them to <80 characters per line
Replace deprecated function calls with their new equivalents
- hide-subtree -> outline-hide-subtree
- show-children -> outline-show-children
- show-subtree -> outline-show-subtree
Require face-remap file explicitly to ensure face-remap-remove-relative is loaded
Add missing type definition to defcustom of org-subtree-slide-heading-level-{1,2,3,4}

After the changes no more warnings are given.

In my tests of the package after the changes i found no changes in behavior but would welcome any additional testing.